### PR TITLE
Change max block size for rooted splitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ The API is the same as for [`CarSplitter`](#class-carsplitter).
 
 The root node is a `dag-cbor` node that is a tuple of the string `/carbites/1`, an array of root CIDs (only seen in first CAR) and an array of block CIDs (all the blocks in the CAR). e.g. `['/carbites/1', ['bafkroot'], ['bafy1', 'bafy2']]`.
 
-Note: The root node is limited to 4MB in size (the largest message IPFS will bitswap). Depending on the settings used to construct the DAG in the CAR, this may mean a split CAR size limit of around 30GiB.
+Note: The root node is limited to 2MiB in size (the largest message IPFS will bitswap). Depending on the settings used to construct the DAG in the CAR, this may mean a split CAR size limit of around 15GiB.
 
 ### `class RootedCarJoiner`
 

--- a/lib/rooted/root-node.js
+++ b/lib/rooted/root-node.js
@@ -18,7 +18,7 @@ export async function mkRootNode (roots, blocks) {
   const value = ['/carbites/1', Array.from(roots), Array.from(blocks)]
   const bytes = encode(value)
   // FIXME: Given a V1 CID of ~36 bytes and the default IPFS chunk size of
-  // 262,144 bytes you'd need to be splitting at 30GiB or more to experience
+  // 262,144 bytes you'd need to be splitting at 15GiB or more to experience
   // this error.
   if (bytes.length >= MAX_SIZE) {
     throw new Error('root node too big. The root node is bigger than 4MiB: the biggest message IPFS will bitswap. Split the CAR into smaller chunks.')

--- a/lib/rooted/root-node.js
+++ b/lib/rooted/root-node.js
@@ -5,7 +5,7 @@ import { Block } from 'multiformats/block'
 
 /** @typedef {['/carbites/1', CID[], CID[]]} RootNode */
 
-const MAX_SIZE = 1024 * 1024 * 4
+const MAX_SIZE = 1024 * 1024 * 2
 
 /**
  * Make a carbites root node. Format: ['/carbites/1', roots, blocks]


### PR DESCRIPTION
Reduce from 4MiB to 2MiB per Bitswap spec https://specs.ipfs.tech/bitswap-protocol/#block-sizes